### PR TITLE
fix: hash verification

### DIFF
--- a/src/telegram-login.ts
+++ b/src/telegram-login.ts
@@ -7,6 +7,7 @@ function verifyTelegramPayload(payload: TelegramLoginPayload, secret: Buffer)  {
   const check = crypto.createHmac('sha256', secret).update(
     Object
     .keys(payload)
+    .filter(key => payload[key])
     .map((key: keyof TelegramLoginPayload) => `${key}=${payload[key]}`)
     .sort()
     .join('\n')


### PR DESCRIPTION
Remove keys with undefined value for proper string concatenation.